### PR TITLE
Add button component

### DIFF
--- a/components/Button/index.tsx
+++ b/components/Button/index.tsx
@@ -2,18 +2,8 @@ import React from "react";
 import clsx from "clsx";
 import { BsArrowRight } from "react-icons/bs";
 
+import styles, { buttonVariantsStyles } from "./styles";
 import { ButtonProps, ButtonVariant } from "./types";
-
-const iconClassNames = "text-2xl ml-8";
-const buttonElementClassNames = "flex border-none outline-none focus:outline-none text-lg items-center bg-orange-100 hover:bg-orange-shade transition-colors duration-200 py-2 px-5 rounded-full";
-const buttonContainerClassNames = "flex pr-5 items-start justify-center py-0 border border-orange-100 hover:border-orange-shade rounded-full";
-
-const buttonElementHoverAnimation = "transform transition-transform duration-200 hover:translate-x-6";
-
-const buttonElementVariantClassNames = {
-  [ButtonVariant.Primary]: "text-black",
-  [ButtonVariant.Secondary]: "text-white",
-};
 
 const Button: React.FC<ButtonProps> = ({
   buttonElementClassName,
@@ -23,23 +13,27 @@ const Button: React.FC<ButtonProps> = ({
   ...rest
 }) => {
   const concatenateButtonElementClassNames = clsx([
+    styles.element,
+    styles.elementAnimation,
     buttonElementClassName,
-    buttonElementClassNames,
-    buttonElementHoverAnimation,
-    buttonElementVariantClassNames[variant],
+    buttonVariantsStyles[variant],
   ]);
 
   const concatenateButtonContainerClassNames = clsx([
-    buttonContainerClassNames,
+    styles.container,
     buttonContainerClassName,
   ]);
 
   return (
     <div role="button" className={concatenateButtonContainerClassNames}>
-      <button type="button" className={concatenateButtonElementClassNames} {...rest}>
+      <button
+        type="button"
+        className={concatenateButtonElementClassNames}
+        {...rest}
+      >
         {children}
 
-        <BsArrowRight className={iconClassNames} />
+        <BsArrowRight className={styles.icon} />
       </button>
     </div>
   );

--- a/components/Button/index.tsx
+++ b/components/Button/index.tsx
@@ -4,33 +4,41 @@ import { BsArrowRight } from "react-icons/bs";
 
 import { ButtonProps, ButtonVariant } from "./types";
 
-const iconClasses = "text-2xl ml-8";
+const iconClassNames = "text-2xl ml-8";
+const buttonElementClassNames = "flex border-none outline-none focus:outline-none text-lg items-center bg-orange-100 hover:bg-orange-shade transition-colors duration-200 py-2 px-5 rounded-full";
+const buttonContainerClassNames = "flex pr-5 items-start justify-center py-0 border border-orange-100 hover:border-orange-shade rounded-full";
 
-const buttonClasses = "flex outline-none focus:outline-none text-lg items-center bg-orange-100 hover:bg-orange-shade transition-colors duration-200 py-2 px-5 rounded-full";
-
-const buttonVariantsStyles = {
+const buttonElementVariantClassNames = {
   [ButtonVariant.Primary]: "text-black",
   [ButtonVariant.Secondary]: "text-white",
 };
 
 const Button: React.FC<ButtonProps> = ({
-  className,
+  buttonElementClassName,
+  buttonContainerClassName,
   variant = ButtonVariant.Primary,
   children,
   ...rest
 }) => {
-  const concatenateClassName = clsx([
-    className,
-    buttonClasses,
-    buttonVariantsStyles[variant],
+  const concatenateButtonElementClassNames = clsx([
+    buttonElementClassNames,
+    buttonElementClassName,
+    buttonElementVariantClassNames[variant],
+  ]);
+
+  const concatenateButtonContainerClassNames = clsx([
+    buttonContainerClassNames,
+    buttonContainerClassName,
   ]);
 
   return (
-    <button type="button" className={concatenateClassName} {...rest}>
-      {children}
+    <div role="button" className={concatenateButtonContainerClassNames}>
+      <button type="button" className={concatenateButtonElementClassNames} {...rest}>
+        {children}
 
-      <BsArrowRight className={iconClasses} />
-    </button>
+        <BsArrowRight className={iconClassNames} />
+      </button>
+    </div>
   );
 };
 

--- a/components/Button/index.tsx
+++ b/components/Button/index.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import clsx from "clsx";
+import { BsArrowRight } from "react-icons/bs";
+
+import { ButtonProps, ButtonVariant } from "./types";
+
+const iconClasses = "text-2xl ml-8";
+
+const buttonClasses = "flex outline-none focus:outline-none text-lg items-center bg-orange-100 hover:bg-orange-shade transition-colors duration-200 py-2 px-5 rounded-full";
+
+const buttonVariantsStyles = {
+  [ButtonVariant.Primary]: "text-black",
+  [ButtonVariant.Secondary]: "text-white",
+};
+
+const Button: React.FC<ButtonProps> = ({
+  className,
+  variant = ButtonVariant.Primary,
+  children,
+  ...rest
+}) => {
+  const concatenateClassName = clsx([
+    className,
+    buttonClasses,
+    buttonVariantsStyles[variant],
+  ]);
+
+  return (
+    <button type="button" className={concatenateClassName} {...rest}>
+      {children}
+
+      <BsArrowRight className={iconClasses} />
+    </button>
+  );
+};
+
+export default Button;

--- a/components/Button/index.tsx
+++ b/components/Button/index.tsx
@@ -8,6 +8,8 @@ const iconClassNames = "text-2xl ml-8";
 const buttonElementClassNames = "flex border-none outline-none focus:outline-none text-lg items-center bg-orange-100 hover:bg-orange-shade transition-colors duration-200 py-2 px-5 rounded-full";
 const buttonContainerClassNames = "flex pr-5 items-start justify-center py-0 border border-orange-100 hover:border-orange-shade rounded-full";
 
+const buttonElementHoverAnimation = "transform transition-transform duration-200 hover:translate-x-6";
+
 const buttonElementVariantClassNames = {
   [ButtonVariant.Primary]: "text-black",
   [ButtonVariant.Secondary]: "text-white",
@@ -21,8 +23,9 @@ const Button: React.FC<ButtonProps> = ({
   ...rest
 }) => {
   const concatenateButtonElementClassNames = clsx([
-    buttonElementClassNames,
     buttonElementClassName,
+    buttonElementClassNames,
+    buttonElementHoverAnimation,
     buttonElementVariantClassNames[variant],
   ]);
 

--- a/components/Button/styles.ts
+++ b/components/Button/styles.ts
@@ -1,0 +1,18 @@
+import { ButtonVariant } from "./types";
+
+const buttonStyles = {
+  icon: "text-2xl ml-8",
+
+  element: "flex border-none outline-none focus:outline-none text-lg items-center bg-orange-100 hover:bg-orange-shade transition-colors duration-200 py-2 px-5 rounded-full",
+
+  container: "flex pr-5 items-start justify-center py-0 border border-orange-100 hover:border-orange-shade rounded-full",
+
+  elementAnimation: "transform transition-transform duration-200 hover:translate-x-6",
+};
+
+export const buttonVariantsStyles = {
+  [ButtonVariant.Primary]: "text-black",
+  [ButtonVariant.Secondary]: "text-white",
+};
+
+export default buttonStyles;

--- a/components/Button/styles.ts
+++ b/components/Button/styles.ts
@@ -7,7 +7,7 @@ const buttonStyles = {
 
   container: "flex pr-5 items-start justify-center py-0 border border-orange-100 hover:border-orange-shade rounded-full",
 
-  elementAnimation: "transform transition-transform duration-200 hover:translate-x-6",
+  elementAnimation: "transform transition-transform duration-200 hover:translate-x-6 focus:translate-x-0",
 };
 
 export const buttonVariantsStyles = {

--- a/components/Button/styles.ts
+++ b/components/Button/styles.ts
@@ -3,7 +3,7 @@ import { ButtonVariant } from "./types";
 const buttonStyles = {
   icon: "text-2xl ml-8",
 
-  element: "flex border-none outline-none focus:outline-none text-lg items-center bg-orange-100 hover:bg-orange-shade transition-colors duration-200 py-2 px-5 rounded-full",
+  element: "flex flex-1 justify-between flex-wrap border-none outline-none focus:outline-none text-lg items-center bg-orange-100 hover:bg-orange-shade transition-colors duration-200 py-2 px-5 rounded-full",
 
   container: "flex pr-5 items-start justify-center py-0 border border-orange-100 hover:border-orange-shade rounded-full",
 

--- a/components/Button/types.ts
+++ b/components/Button/types.ts
@@ -1,0 +1,10 @@
+import { HTMLAttributes } from "react";
+
+export enum ButtonVariant {
+  "Primary",
+  "Secondary"
+}
+
+export interface ButtonProps extends HTMLAttributes<HTMLButtonElement> {
+  variant: ButtonVariant;
+}

--- a/components/Button/types.ts
+++ b/components/Button/types.ts
@@ -5,6 +5,10 @@ export enum ButtonVariant {
   "Secondary"
 }
 
-export interface ButtonProps extends HTMLAttributes<HTMLButtonElement> {
-  variant: ButtonVariant;
+type ButtonElementAttributes = HTMLAttributes<HTMLButtonElement>;
+
+export interface ButtonProps extends Omit<ButtonElementAttributes, "className"> {
+  buttonContainerClassName?: string;
+  buttonElementClassName?: ButtonElementAttributes["className"];
+  variant?: ButtonVariant;
 }

--- a/components/Header/MobileNavbar.tsx
+++ b/components/Header/MobileNavbar.tsx
@@ -10,7 +10,6 @@ import { headerNavbarLinks } from "./constants";
 const navbarInitialMotionStyle = {
   top: 0,
   right: 0,
-  opacity: 0,
   left: "100%",
 };
 
@@ -18,7 +17,6 @@ const navbarMotionStyles = {
   exit: navbarInitialMotionStyle,
   initial: navbarInitialMotionStyle,
   animate: {
-    opacity: 1,
     right: 0,
     left: "unset",
   },

--- a/components/Header/MobileNavbar.tsx
+++ b/components/Header/MobileNavbar.tsx
@@ -10,6 +10,7 @@ import { headerNavbarLinks } from "./constants";
 const navbarInitialMotionStyle = {
   top: 0,
   right: 0,
+  opacity: 0,
   left: "100%",
 };
 
@@ -18,6 +19,7 @@ const navbarMotionStyles = {
   initial: navbarInitialMotionStyle,
   animate: {
     right: 0,
+    opacity: 1,
     left: "unset",
   },
 };

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "framer-motion": "^2.9.4",
     "next": "^10.0.1",
     "next-seo": "^4.13.0",
+    "polished": "^4.0.3",
     "postcss-import": "^12.0.1",
     "react": "16.14.0",
     "react-dom": "16.14.0",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,18 +1,11 @@
 import Head from "next/head";
 
-import Button from "components/Button";
-import { ButtonVariant } from "components/Button/types";
-
 const App: React.FC = () => (
   <>
     <Head>
       <title>Floripa+ | Torne a ilha em um lugar melhor</title>
     </Head>
-    <main id="page-wrapper" className="flex flex-col h-screen w-screen justify-center items-center bg-background-light">
-      <Button variant={ButtonVariant.Primary} buttonContainerClassName="mb-10">Primary</Button>
-
-      <Button variant={ButtonVariant.Secondary}>Secondary</Button>
-    </main>
+    <main id="page-wrapper" className="h-screen w-screen flex justify-center items-center bg-background-light" />
   </>
 );
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -9,7 +9,7 @@ const App: React.FC = () => (
       <title>Floripa+ | Torne a ilha em um lugar melhor</title>
     </Head>
     <main id="page-wrapper" className="flex flex-col h-screen w-screen justify-center items-center bg-background-light">
-      <Button variant={ButtonVariant.Primary} className="mb-10">Primary</Button>
+      <Button variant={ButtonVariant.Primary} buttonContainerClassName="mb-10">Primary</Button>
 
       <Button variant={ButtonVariant.Secondary}>Secondary</Button>
     </main>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,11 +1,18 @@
 import Head from "next/head";
 
+import Button from "components/Button";
+import { ButtonVariant } from "components/Button/types";
+
 const App: React.FC = () => (
   <>
     <Head>
       <title>Floripa+ | Torne a ilha em um lugar melhor</title>
     </Head>
-    <main id="page-wrapper" className="h-screen w-screen flex justify-center items-center bg-background-light" />
+    <main id="page-wrapper" className="flex flex-col h-screen w-screen justify-center items-center bg-background-light">
+      <Button variant={ButtonVariant.Primary} className="mb-10">Primary</Button>
+
+      <Button variant={ButtonVariant.Secondary}>Secondary</Button>
+    </main>
   </>
 );
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -26,7 +26,7 @@ module.exports = {
         "yellow-100": "#DDA158",
         "orange-100": reuseColors["orange-100"],
         "orange-200": "#FC9414",
-        "orange-shade": shade(0.2, reuseColors["orange-100"]),
+        "orange-shade": shade(0.1, reuseColors["orange-100"]),
         "background-light": "#F2F2F2",
       },
     },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,11 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+const { shade } = require("polished");
+
 const purgeExtensions = "*.{js,ts,jsx,tsx}";
+
+const reuseColors = {
+  "orange-100": "#FB8F0A",
+};
 
 module.exports = {
   purge: {
@@ -17,8 +24,9 @@ module.exports = {
       colors: {
         black: "#0d0c0f",
         "yellow-100": "#DDA158",
-        "orange-100": "#FB8F0A",
+        "orange-100": reuseColors["orange-100"],
         "orange-200": "#FC9414",
+        "orange-shade": shade(0.2, reuseColors["orange-100"]),
         "background-light": "#F2F2F2",
       },
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1033,6 +1033,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.12.0":
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.5.tgz#410e7e487441e1b360c29be715d870d9b985882e"
+  integrity sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.10.4", "@babel/template@^7.7.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.10.4.tgz#3251996c4200ebc71d1a8fc405fba940f36ba278"
@@ -5329,6 +5336,13 @@ pnp-webpack-plugin@1.6.4:
   integrity sha512-7Wjy+9E3WwLOEL30D+m8TSTF7qJJUJLONBnwQp0518siuMxUQUbgZwssaFX+QKlZkjHZcw/IpZCt/H0srrntSg==
   dependencies:
     ts-pnp "^1.1.6"
+
+polished@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/polished/-/polished-4.0.3.tgz#e2bde249f8884bdabc6997dd3eca225ee32f7a26"
+  integrity sha512-yOALHMrqcYHlHIxFkHvGX8NGsjsbSaYMZ8Z3uEElVpzF5ZgNmTgqMOh4bnSVXGC6sXjBTZCH6+GebTRWhJR4zQ==
+  dependencies:
+    "@babel/runtime" "^7.12.0"
 
 popmotion@9.0.0-rc.20:
   version "9.0.0-rc.20"


### PR DESCRIPTION
This PR implements the button component reused on many sections 

### Usage:

```
 <Button 
	buttonContainerClassName="mb-10" 
	variant={ButtonVariant.Secondary}
 >
   Conheça a nossa missão
 </Button>

 <Button>Comparecer</Button>
```

There are some props to extend the inner styles of the component:

- `buttonContainerClassName`: A class that will be passed to the ``div`` around the ``button`` element.
- `buttonElementClassName`: A class that will be passed to the ``button`` element.

### Styles

![buttons](https://user-images.githubusercontent.com/48022589/98149666-45d92900-1eac-11eb-897a-3cd02fb45e83.png)

Hovering & Focusing:

![chrome-capture (1)](https://user-images.githubusercontent.com/48022589/98149862-889b0100-1eac-11eb-83c1-9781cc3d8218.gif)
