### PR TITLE
Add achievements section

### DIFF
--- a/components/MaxWidthContainer/index.tsx
+++ b/components/MaxWidthContainer/index.tsx
@@ -1,12 +1,15 @@
-import React, { HTMLAttributes } from "react";
+import React from "react";
 import clsx from "clsx";
 
-const MaxWidthContainer: React.FC<HTMLAttributes<HTMLDivElement>> = ({
+import { MaxWidthContainerProps } from "./types";
+
+const MaxWidthContainer: React.FC<MaxWidthContainerProps> = ({
   children,
   className,
+  maxWidth = "max-w-screen-lg",
   ...rest
 }) => {
-  const concatenateClassName = clsx("max-w-screen-lg mx-auto w-full", className);
+  const concatenateClassName = clsx("mx-auto w-full", maxWidth, className);
 
   return (
     <div {...rest} className={concatenateClassName}>

--- a/components/MaxWidthContainer/types.ts
+++ b/components/MaxWidthContainer/types.ts
@@ -1,0 +1,5 @@
+import { HTMLAttributes } from "react";
+
+export interface MaxWidthContainerProps extends HTMLAttributes<HTMLDivElement> {
+  maxWidth?: string;
+}

--- a/components/Sections/Achievements/Content.tsx
+++ b/components/Sections/Achievements/Content.tsx
@@ -1,9 +1,51 @@
 import React from "react";
 
-import { AchievementsSectionContentProps } from "./types";
+import MaxWidthContainer from "components/MaxWidthContainer";
 
-const AchievementsSectionContent: React.FC<AchievementsSectionContentProps> = () => (
-  <section className="bg-black w-full" />
+import { achievementsSectionContent } from "./constants";
+import { AchievementsSectionContentProps, AchievementItemProps } from "./types";
+
+const AchievementItem: React.FC<AchievementItemProps> = ({
+  achievedNumber,
+  label,
+}) => (
+  <div className="flex flex-col">
+    <h2 className="text-white text-6xl font-bold">
+      {achievedNumber}
+    </h2>
+
+    <h3 className="text-white text-base uppercase font-medium">
+      {label}
+    </h3>
+  </div>
+);
+
+const AchievementsSectionContent: React.FC<AchievementsSectionContentProps> = ({
+  title = achievementsSectionContent.title,
+  freeEventsLabel = achievementsSectionContent.freeEventsLabel,
+  freeEventsNumber = achievementsSectionContent.freeEventsNumber,
+  organizationsHelpedLabel = achievementsSectionContent.organizationsHelpedLabel,
+  organizationsHelpedNumber = achievementsSectionContent.organizationsHelpedNumber,
+}) => (
+  <section className="flex text-center flex-col py-10 bg-black w-full">
+    <MaxWidthContainer maxWidth="max-w-lg">
+      <h1 className="text-white text-lg uppercase font-medium">
+        {title}
+      </h1>
+
+      <div className="mt-5 w-full grid grid-cols-2 gap-x-5">
+        <AchievementItem
+          label={freeEventsLabel}
+          achievedNumber={freeEventsNumber}
+        />
+
+        <AchievementItem
+          label={organizationsHelpedLabel}
+          achievedNumber={organizationsHelpedNumber}
+        />
+      </div>
+    </MaxWidthContainer>
+  </section>
 );
 
 export default AchievementsSectionContent;

--- a/components/Sections/Achievements/Content.tsx
+++ b/components/Sections/Achievements/Content.tsx
@@ -9,7 +9,7 @@ const AchievementItem: React.FC<AchievementItemProps> = ({
   achievedNumber,
   label,
 }) => (
-  <div className="flex flex-col">
+  <div className="flex flex-col px-8 md:px-0">
     <h2 className="text-white text-6xl font-bold">
       {achievedNumber}
     </h2>

--- a/components/Sections/Achievements/Content.tsx
+++ b/components/Sections/Achievements/Content.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+import { AchievementsSectionContentProps } from "./types";
+
+const AchievementsSectionContent: React.FC<AchievementsSectionContentProps> = () => (
+  <section className="bg-black w-full" />
+);
+
+export default AchievementsSectionContent;

--- a/components/Sections/Achievements/constants.ts
+++ b/components/Sections/Achievements/constants.ts
@@ -1,6 +1,8 @@
 export const achievementsSectionContent = {
   title: "O que o Floripa+ já fez em 2020?",
   freeEventsNumber: 21,
+  freeEventsLabel: "Eventos Gratuitos",
+  organizationsHelpedLabel: "Ongs Ajudadas",
   organizationsHelpedNumber: 30,
 };
 

--- a/components/Sections/Achievements/constants.ts
+++ b/components/Sections/Achievements/constants.ts
@@ -1,0 +1,6 @@
+export const achievementsSectionContent = {
+  title: "O que o Floripa+ já fez em 2020?",
+  freeEventsNumber: 21,
+  organizationsHelpedNumber: 30,
+};
+

--- a/components/Sections/Achievements/index.tsx
+++ b/components/Sections/Achievements/index.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+import AchievementsSectionContent from "./Content";
+
+const AchievementsSection: React.FC = () => (
+  <AchievementsSectionContent />
+);
+
+export default AchievementsSection;

--- a/components/Sections/Achievements/types.ts
+++ b/components/Sections/Achievements/types.ts
@@ -1,5 +1,12 @@
 export interface AchievementsSectionContentProps {
   title?: string;
+  freeEventsLabel?: string;
   freeEventsNumber?: number;
+  organizationsHelpedLabel?: string;
   organizationsHelpedNumber?: number;
+}
+
+export interface AchievementItemProps {
+  achievedNumber: number;
+  label: string;
 }

--- a/components/Sections/Achievements/types.ts
+++ b/components/Sections/Achievements/types.ts
@@ -1,0 +1,5 @@
+export interface AchievementsSectionContentProps {
+  title?: string;
+  freeEventsNumber?: number;
+  organizationsHelpedNumber?: number;
+}

--- a/components/Sections/Introduction/Content.tsx
+++ b/components/Sections/Introduction/Content.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import Image from "next/image";
-import MaxWidthContainer from "components/MaxWidthContainer";
 
+import MaxWidthContainer from "components/MaxWidthContainer";
 import Button from "components/Button";
 import { ButtonVariant } from "components/Button/types";
 import ScrollLink from "components/ScrollLink";
@@ -17,7 +17,7 @@ const IntroductionSectionContent: React.FC<IntroductionSectionContentProps> = ({
 }) => (
   <section
     id={introductionSectionId}
-    className="flex items-center py-10 px-5 md:p-20 relative h-section-introduction bg-white"
+    className="flex items-center py-10 px-5 md:p-20 relative h-section-introduction-mobile md:h-section-introduction-desktop bg-white"
   >
     <Image
       src={backgroundSrc}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,6 +3,7 @@ import Head from "next/head";
 import MaxWidthContainer from "components/MaxWidthContainer";
 import IntroductionSection from "components/Sections/Introduction";
 import MissionSection from "components/Sections/Mission";
+import AchievementsSection from "components/Sections/Achievements";
 
 const App: React.FC = () => (
   <>
@@ -11,6 +12,7 @@ const App: React.FC = () => (
     </Head>
     <main id="page-wrapper" className="pt-header-mobile md:pt-header-desktop flex flex-col justify-start bg-background-light">
       <IntroductionSection />
+      <AchievementsSection />
 
       <MaxWidthContainer>
         <MissionSection />

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -37,7 +37,8 @@ module.exports = {
       },
       height: {
         ...reuseComponentsLengths,
-        "section-introduction": "30rem",
+        "section-introduction-desktop": `calc(100vh - ${reuseComponentsLengths["header-desktop"]})`,
+        "section-introduction-mobile": `calc(100vh - ${reuseComponentsLengths["header-mobile"]})`,
       },
       width: {
         22: "22rem",


### PR DESCRIPTION
This PR adds the achievements section 

![Screenshot from 2020-11-05 09-33-12](https://user-images.githubusercontent.com/48022589/98241619-f6493a80-1f49-11eb-9982-6ae08c804380.png)

---

I've also made some unrelated changes 

- The introduction section is now covering the whole viewport except the header height

![Screenshot from 2020-11-05 09-36-43](https://user-images.githubusercontent.com/48022589/98241948-6fe12880-1f4a-11eb-862a-6092e9c3b937.png)

The user is now able to see a full section at the first access, instead of incomplete ones.

- `MaxWidthContainer` can receive a different max-width 

The default max-width is ``max-w-screen-lg`` and it's possible to override it by passing via prop 

```
<MaxWidthContainer maxWidth="max-w-screen-sm" />
```

By doing that, it's possible to reuse utilities such as ``mx-auto w-full`` 