### PR TITLE
Not execute useLayoutEffect on the server

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,4 @@
-# Lint all files except .eslintrc.js and node_modules
+# Lint all files except .eslintrc.js 
 !.eslintrc.js
 
 # Dependencies

--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,5 +1,5 @@
 {
-  "src/**/*.js": [
+  "src/**/*.{ts,tsx}": [
     "yarn linter",
     "git add"
   ]

--- a/components/Footer/Content.tsx
+++ b/components/Footer/Content.tsx
@@ -31,7 +31,7 @@ const FooterContent: React.FC<FooterContentProps> = ({
 
   const socialMediaLinkClasses = clsx(subtitleClassName, "footer-social-media-link");
 
-  const contactEmailClasses = clsx(subtitleClassName, borderSubtitleClassName);
+  const contactLinkClasses = clsx(subtitleClassName, borderSubtitleClassName);
 
   return (
     <footer
@@ -58,7 +58,7 @@ const FooterContent: React.FC<FooterContentProps> = ({
         </FooterContentItem>
 
         <FooterContentItem title={footerContactTitle}>
-          <a href={mailTo} className={contactEmailClasses}>
+          <a href={mailTo} className={contactLinkClasses}>
             {email}
           </a>
         </FooterContentItem>

--- a/components/Header/constants.ts
+++ b/components/Header/constants.ts
@@ -1,8 +1,8 @@
 import { footerId } from "components/Footer/constants";
-import { actionsSectionId } from "components/Sections/Actions/constants";
-import { donationsSectionId } from "components/Sections/Donations/constants";
 import { teamSectionId } from "components/Sections/Team/constants";
+import { actionsSectionId } from "components/Sections/Actions/constants";
 import { missionSectionId } from "components/Sections/Mission/constants";
+import { donationsSectionId } from "components/Sections/Donations/constants";
 
 /**
  * Defines the links to be show on the header navbar

--- a/components/Sections/Team/Content.tsx
+++ b/components/Sections/Team/Content.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import MembersSlider from "components/Slider/MembersSlider";
+import TeamSlider from "components/Slider/TeamSlider";
 import Section from "components/Sections/Section";
 
 import { TeamSectionContentProps } from "./types";
@@ -17,7 +17,7 @@ const TeamSectionContent: React.FC<TeamSectionContentProps> = ({
     text={text}
   >
     <div className="w-full mt-12">
-      <MembersSlider members={members} />
+      <TeamSlider members={members} />
     </div>
   </Section>
 );

--- a/components/Sections/Team/constants.tsx
+++ b/components/Sections/Team/constants.tsx
@@ -39,4 +39,4 @@ export const teamSectionContent = {
   members,
 };
 
-export const teamSectionId = "members-section";
+export const teamSectionId = "team-section";

--- a/components/Slider/MembersSlider/index.tsx
+++ b/components/Slider/MembersSlider/index.tsx
@@ -10,7 +10,6 @@ const MembersSlider: React.FC<MembersSliderProps> = ({
 }) => (
   <Slider
     pauseOnHover={false}
-    autoplay
     infinite
     speed={5000}
   >
@@ -20,9 +19,9 @@ const MembersSlider: React.FC<MembersSliderProps> = ({
       photoUrl,
     }) => (
       <div className="py-2" key={id}>
-        <div className="min-h-slider-item text-left flex flex-col justify-between text-black bg-white-light rounded-lg mx-2 p-5">
-          <header className="w-full text-center">
-            <h5 className="text-2xl font-semibold">
+        <div className="min-h-slider-item flex flex-col justify-between text-black bg-white-light rounded-lg mx-2 p-5">
+          <header className="w-full">
+            <h5 className="text-2xl text-center font-semibold">
               {name}
             </h5>
           </header>

--- a/components/Slider/MembersSlider/index.tsx
+++ b/components/Slider/MembersSlider/index.tsx
@@ -10,6 +10,7 @@ const MembersSlider: React.FC<MembersSliderProps> = ({
 }) => (
   <Slider
     pauseOnHover={false}
+    autoplay
     infinite
     speed={5000}
   >
@@ -19,9 +20,9 @@ const MembersSlider: React.FC<MembersSliderProps> = ({
       photoUrl,
     }) => (
       <div className="py-2" key={id}>
-        <div className="min-h-slider-item flex flex-col justify-between text-black bg-white-light rounded-lg mx-2 p-5">
-          <header className="w-full">
-            <h5 className="text-2xl text-center font-semibold">
+        <div className="min-h-slider-item text-left flex flex-col justify-between text-black bg-white-light rounded-lg mx-2 p-5">
+          <header className="w-full text-center">
+            <h5 className="text-2xl font-semibold">
               {name}
             </h5>
           </header>

--- a/components/Slider/TeamSlider/index.tsx
+++ b/components/Slider/TeamSlider/index.tsx
@@ -3,9 +3,9 @@ import Image from "next/image";
 
 import Slider from "components/Slider";
 
-import { MembersSliderProps } from "./types";
+import { TeamSliderProps } from "./types";
 
-const MembersSlider: React.FC<MembersSliderProps> = ({
+const TeamSlider: React.FC<TeamSliderProps> = ({
   members,
 }) => (
   <Slider
@@ -42,4 +42,4 @@ const MembersSlider: React.FC<MembersSliderProps> = ({
   </Slider>
 );
 
-export default MembersSlider;
+export default TeamSlider;

--- a/components/Slider/TeamSlider/types.ts
+++ b/components/Slider/TeamSlider/types.ts
@@ -1,5 +1,5 @@
 import { Member } from "components/Sections/Team/types";
 
-export interface MembersSliderProps {
+export interface TeamSliderProps {
   members: Member[];
 }

--- a/contexts/tailwindBreakpointsProvider/index.tsx
+++ b/contexts/tailwindBreakpointsProvider/index.tsx
@@ -1,12 +1,21 @@
 import React from "react";
 import { BreakpointsProvider } from "react-with-breakpoints";
 
+import useHasMounted from "hooks/useIsMounted";
 import { tailwindBreakpoints } from "styles/tailwind";
 
-const TailwindBreakpointsProvider: React.FC = ({ children }) => (
-  <BreakpointsProvider breakpoints={tailwindBreakpoints}>
-    {children}
-  </BreakpointsProvider>
-);
+const TailwindBreakpointsProvider: React.FC = ({ children }) => {
+  const hasMounted = useHasMounted();
+
+  if (!hasMounted) {
+    return <>{children}</>;
+  }
+
+  return (
+    <BreakpointsProvider breakpoints={tailwindBreakpoints}>
+      {children}
+    </BreakpointsProvider>
+  );
+};
 
 export default TailwindBreakpointsProvider;

--- a/hooks/useIsMounted/index.tsx
+++ b/hooks/useIsMounted/index.tsx
@@ -1,0 +1,19 @@
+import { useState, useEffect } from "react";
+
+/**
+ * Handles the mounted state of the component.
+ *
+ * Useful for cases where a content should only be rendered on the browser
+ * and the DOM should stay the same on the server and on the re-hydration process.
+ */
+const useHasMounted = (): boolean => {
+  const [hasMounted, setHasMounted] = useState(false);
+
+  useEffect(() => {
+    setHasMounted(true);
+  }, []);
+
+  return hasMounted;
+};
+
+export default useHasMounted;


### PR DESCRIPTION
This PR implements a hook to manage the mounted state of a component/page. By knowing that the content hasn't mounted yet, we can render different contents on the server and when the page mounts for the first time on the client. 

The DOM generated on the server should stay the same as the one generated on the rehydration process on the client.   

```
const TailwindBreakpointsProvider: React.FC = ({ children }) => {
  const hasMounted = useHasMounted();
  
  // True on the server -> App hasn't mounted yet
  // True when the app is rehydrated -> React is starting to generate the DOM and the App hasn't mounted yet
  if (!hasMounted) {
    return <>{children}</>;
  }
```