### PR TITLE
Add scroll to top button 

### DIFF
--- a/components/Header/MobileNavbar.tsx
+++ b/components/Header/MobileNavbar.tsx
@@ -63,10 +63,8 @@ const NavbarMobile: React.FC = () => {
             <motion.nav
               key="navbar"
               ref={navElementRef}
-              exit={navbarMotionStyles.exit}
-              initial={navbarMotionStyles.initial}
-              animate={navbarMotionStyles.animate}
               className="flex flex-col w-64 p-5 h-screen fixed bg-gray-900"
+              {...navbarMotionStyles}
             >
               <header className="w-full flex justify-end">
                 <button

--- a/components/ScrollLink/index.tsx
+++ b/components/ScrollLink/index.tsx
@@ -14,7 +14,7 @@ const ScrollLink: React.FC<ScrollLinkProps> = ({
   const [headerHeight, setHeaderHeight] = useState(0);
 
   useEffect(() => {
-    setHeaderHeight(-(document?.querySelector<HTMLElement>(`#${headerId}`)?.offsetHeight));
+    setHeaderHeight(-(document?.getElementById(headerId)?.offsetHeight));
   }, []);
 
   const buttonHref = `#${to}`;

--- a/components/ScrollTopButton/index.tsx
+++ b/components/ScrollTopButton/index.tsx
@@ -1,14 +1,39 @@
 import React from "react";
 import { FaChevronUp } from "react-icons/fa";
+import { AnimatePresence, motion } from "framer-motion";
 
 import ScrollLink from "components/ScrollLink";
 import { introductionSectionId } from "components/Sections/Introduction/constants";
 
-const ScrollTopButton: React.FC = () => (
-  <ScrollLink to={introductionSectionId} className="fixed bottom-2 right-2">
-    <button type="button" className="flex justify-center items-center bg-orange-100 w-10 h-10 rounded-full">
-      <FaChevronUp className="text-white" />
-    </button>
+import { ScrollTopButtonProps } from "./types";
+
+const buttonInitialMotionStyle = {
+  opacity: 0,
+};
+
+const buttonMotionStyles = {
+  exit: buttonInitialMotionStyle,
+  initial: buttonInitialMotionStyle,
+  animate: {
+    opacity: 1,
+  },
+};
+
+const ScrollTopButton: React.FC<ScrollTopButtonProps> = ({ isVisible }) => (
+  <ScrollLink to={introductionSectionId} className="fixed bottom-2 right-2 z-10">
+    <AnimatePresence>
+      {
+        isVisible && (
+          <motion.button
+            type="button"
+            className="flex justify-center items-center bg-orange-100 w-10 h-10 rounded-full"
+            {...buttonMotionStyles}
+          >
+            <FaChevronUp className="text-white" />
+          </motion.button>
+        )
+      }
+    </AnimatePresence>
   </ScrollLink>
 );
 

--- a/components/ScrollTopButton/index.tsx
+++ b/components/ScrollTopButton/index.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { FaChevronUp } from "react-icons/fa";
+
+import ScrollLink from "components/ScrollLink";
+import { introductionSectionId } from "components/Sections/Introduction/constants";
+
+const ScrollTopButton: React.FC = () => (
+  <ScrollLink to={introductionSectionId} className="fixed bottom-2 right-2">
+    <button type="button" className="flex justify-center items-center bg-orange-100 w-10 h-10 rounded-full">
+      <FaChevronUp className="text-white" />
+    </button>
+  </ScrollLink>
+);
+
+export default ScrollTopButton;

--- a/components/ScrollTopButton/types.ts
+++ b/components/ScrollTopButton/types.ts
@@ -1,0 +1,3 @@
+export interface ScrollTopButtonProps {
+  isVisible: boolean;
+}

--- a/components/Sections/Introduction/index.tsx
+++ b/components/Sections/Introduction/index.tsx
@@ -1,10 +1,12 @@
 import React from "react";
 import Image from "next/image";
+import { useTrackVisibility } from "react-intersection-observer-hook";
 
 import MaxWidthContainer from "components/MaxWidthContainer";
 import Touchable from "components/Touchable";
 import ScrollLink from "components/ScrollLink";
 import { orgInfoId } from "components/Sections/OrgInfo/constants";
+import ScrollTopButton from "components/ScrollTopButton";
 
 import { IntroductionSectionProps } from "./types";
 import { introductionSectionId, introductionSectionFixtures } from "./constants";
@@ -13,32 +15,41 @@ const IntroductionSection: React.FC<IntroductionSectionProps> = ({
   backgroundImageLink = introductionSectionFixtures.backgroundImageLink,
   buttonText = introductionSectionFixtures.buttonText,
   title = introductionSectionFixtures.title,
-}) => (
-  <section
-    id={introductionSectionId}
-    className="flex items-center py-10 px-5 md:p-20 relative h-mobile-screen md:h-desktop-screen bg-white"
-  >
-    <Image
-      src={backgroundImageLink}
-      alt="Florianópolis"
-      className="absolute z-10 object-cover object-center h-full w-full"
-      layout="fill"
-      quality={100}
-      loading="eager"
-    />
+}) => {
+  const [ref, { isVisible: isIntroductionSectionVisible }] = useTrackVisibility();
 
-    <MaxWidthContainer className="z-20">
-      <h1 className="text-gray-200 w-full md:w-30 font-bold text-4xl">
-        {title}
-      </h1>
+  return (
+    <>
+      <section
+        ref={ref}
+        id={introductionSectionId}
+        className="flex items-center py-10 px-5 md:p-20 relative h-mobile-screen md:h-desktop-screen bg-white"
+      >
+        <Image
+          src={backgroundImageLink}
+          alt="Florianópolis"
+          className="absolute z-10 object-cover object-center h-full w-full"
+          layout="fill"
+          quality={100}
+          loading="eager"
+        />
 
-      <ScrollLink to={orgInfoId}>
-        <Touchable tabIndex={-1} touchableWrapperClassName="mt-10 w-full md:w-22">
-          {buttonText}
-        </Touchable>
-      </ScrollLink>
-    </MaxWidthContainer>
-  </section>
-);
+        <MaxWidthContainer className="z-20">
+          <h1 className="text-gray-200 w-full md:w-30 font-bold text-4xl">
+            {title}
+          </h1>
+
+          <ScrollLink to={orgInfoId}>
+            <Touchable tabIndex={-1} touchableWrapperClassName="mt-10 w-full md:w-22">
+              {buttonText}
+            </Touchable>
+          </ScrollLink>
+        </MaxWidthContainer>
+      </section>
+
+      <ScrollTopButton isVisible={!isIntroductionSectionVisible} />
+    </>
+  );
+};
 
 export default IntroductionSection;

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "react": "16.14.0",
     "react-dom": "16.14.0",
     "react-icons": "^3.11.0",
+    "react-intersection-observer-hook": "^1.0.4",
     "react-scroll": "^1.8.1",
     "react-slick": "^0.27.13",
     "react-with-breakpoints": "^4.0.4",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -17,7 +17,7 @@ const App: React.FC<AppProps> = ({ Component, pageProps }) => (
     <DefaultSeo {...seoConfig} />
     <ContextProviders>
       <Header />
-      <main id="page-wrapper" className="pt-header-mobile md:pt-header-desktop flex flex-col justify-start bg-white-shade">
+      <main id="page-wrapper" className="relative pt-header-mobile md:pt-header-desktop flex flex-col justify-start bg-white-shade">
         <Component {...pageProps} />
       </main>
     </ContextProviders>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -9,7 +9,6 @@ import ActionsSection from "components/Sections/Actions";
 import TeamMembersSection from "components/Sections/TeamMembers";
 import Footer from "components/Footer";
 import getMainPageContent from "queries/getMainPageContentQuery";
-import ScrollTopButton from "components/ScrollTopButton";
 
 export const getStaticProps = async () => {
   try {
@@ -64,7 +63,6 @@ const MainPage: React.FC< InferGetStaticPropsType<typeof getStaticProps>> = ({
     <MissionSection orgInfos={orgInfos} />
     <TeamMembersSection {...teamMembersSection} />
     <Footer {...footer} />
-    <ScrollTopButton />
   </>
 );
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -9,6 +9,7 @@ import ActionsSection from "components/Sections/Actions";
 import TeamMembersSection from "components/Sections/TeamMembers";
 import Footer from "components/Footer";
 import getMainPageContent from "queries/getMainPageContentQuery";
+import ScrollTopButton from "components/ScrollTopButton";
 
 export const getStaticProps = async () => {
   try {
@@ -63,6 +64,7 @@ const MainPage: React.FC< InferGetStaticPropsType<typeof getStaticProps>> = ({
     <MissionSection orgInfos={orgInfos} />
     <TeamMembersSection {...teamMembersSection} />
     <Footer {...footer} />
+    <ScrollTopButton />
   </>
 );
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -52,6 +52,9 @@ module.exports = {
       minHeight: {
         "slider-item": "24rem",
       },
+      inset: {
+        2: "2rem",
+      },
     },
     fontFamily: {
       body: ["Montserrat", "Arial", "sans-serif"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -7379,6 +7379,11 @@ react-icons@^3.11.0:
   dependencies:
     camelcase "^5.0.0"
 
+react-intersection-observer-hook@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/react-intersection-observer-hook/-/react-intersection-observer-hook-1.0.4.tgz#6dc59e982a7b73c4acc3a446e375769c4d359650"
+  integrity sha512-8Bll+mgiLIxk1uwpTsS2V0FZYWTubmNu0HQQbz1dGQ+WJBUg7rl8CZbEw/SqEQFeghU7zo+Z91K/O4FaTmqD0A==
+
 react-is@16.13.1, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"


### PR DESCRIPTION
## Description

This PR implements a button that scrolls directly to the introduction section. 

It only appears when the section isn't appearing in the viewport anymore. 

## Implementation Details 

```
const [ref, { isVisible: isIntroductionSectionVisible }] = useTrackVisibility();

 <ScrollTopButton isVisible={!isIntroductionSectionVisible} />
```

The ``AnimatePresence`` component from ``framer-motion`` applies predefined styles when the component is mounted/unmounted from the screen:

```
const buttonInitialMotionStyle = {
  opacity: 0,
};

const buttonMotionStyles = {
  exit: buttonInitialMotionStyle,
  initial: buttonInitialMotionStyle,
  animate: {
    opacity: 1,
  },
};

```

```
return (
 <AnimatePresence>
      {
        isVisible && (
          <motion.button
            type="button"
            className="flex justify-center items-center bg-orange-100 w-10 h-10 rounded-full"
            {...buttonMotionStyles}
          >
            <FaChevronUp className="text-white" />
          </motion.button>
        )
      }
 </AnimatePresence>
)
```

## Implementation Styles

![Scroll To Top](https://user-images.githubusercontent.com/48022589/99887456-5830c200-2c23-11eb-8535-e77736d212b4.gif)
